### PR TITLE
Target href of object clicked, not first object of collection.

### DIFF
--- a/jquery.confirm.js
+++ b/jquery.confirm.js
@@ -20,7 +20,7 @@
 		this.click(function(e) {
 			e.preventDefault();
 
-			$.confirm(options);
+			$.confirm(options, e);
 		});
 
 		return this;
@@ -30,7 +30,7 @@
 	 * Show a confirmation dialog
 	 * @param options {text, confirm, cancel, confirmButton, cancelButton, post}
 	 */
-	$.confirm = function(options) {
+	$.confirm = function(options, e) {
 		// Options
 		if (typeof options === 'undefined') {
 			options = {};
@@ -49,7 +49,7 @@
 		}
 		if (typeof options.confirm === 'undefined') {
 			options.confirm = function(o) {
-				var url = o.attr('href');
+				var url = e.currentTarget.attributes['href'].value;
 				if (options.post) {
 					var form = $('<form method="post" class="hide" action="' + url + '"></form>');
 					$("body").append(form);


### PR DESCRIPTION
I ran into an issue when targeting a group links, i.e. $('a.confirm') all links with the confirm class. In that case o from o.attr('href') is a collection of all the a.confirm links on the page and o.attr('href') returns the href of the first link in the collection. This results in first link in the collection being followed no matter what link is clicked.

My fix passes the event target in as one of the arguments, the href is then fetched from the link that triggered the event. It's worked great for me!
