### PR TITLE
fix bug in IE/Edge for not support native .closest(), use jQuery instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ Confirm dialogs for buttons and links.
 
 Chat room: [![](https://badges.gitter.im/myclabs/jquery.confirm.png)](https://gitter.im/myclabs/jquery.confirm)
 
+> **⚠ WARNING: No maintenance intended**  
+> This package is not actively maintained.
+
 ## Requirements
 
 - jQuery > 1.8

--- a/jquery.confirm.js
+++ b/jquery.confirm.js
@@ -81,7 +81,7 @@
                     || (typeof dataOptions.submitForm == "undefined" && options.submitForm)
                     || (typeof dataOptions.submitForm == "undefined" && typeof options.submitForm == "undefined" && $.confirm.options.submitForm)
                 ) {
-                    e.target.closest("form").submit();
+                    $(e.target).closest("form").submit();
                 } else {
                     var url = e && (('string' === typeof e && e) || (e.currentTarget && e.currentTarget.attributes['href'].value));
                     if (url) {


### PR DESCRIPTION
Problem:
In IE/Edge when using the `submit-form` option the submit event wil not fire because of javascript error: "Object doesn't support property or method 'closest'". Because IE/Edge does not support the vanilla feature export yet (see: http://caniuse.com/#feat=element-closest).

Fix:
Make the e.target element a jQuery object so it can use the jQuery .closest() method.